### PR TITLE
PTAL #44 suspend cron execution in maint mode if no exempt IPs

### DIFF
--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -328,7 +328,9 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
           return false;
         }
       }
-      $maint = $this->maintenance->isOn();
+      $exempt = $this->maintenance->getAddressInfo();
+      /* Suspend crons in maintenance mode if no internal testing IPs are present */
+      $maint = $this->maintenance->isOn() && empty($exempt);
       if ($maint) {
          print "Crons suspended due to maintenance mode being enabled \n";
          return false;


### PR DESCRIPTION
PR for https://github.com/magemojo/m2-ce-cron/issues/44 
Enhancement which allows crons to run when developers and testers are validating the site. Checks for existence of exempt IPs for maintenance page and suspends only if maintenance is on and the exemption list is empty.

