### PR TITLE
Fix module sequencing

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-<module name="MageMojo_Cron" setup_version="1.2.5">
-</module>
+    <module name="MageMojo_Cron" setup_version="1.2.5">
+        <sequence>
+            <module name="Magento_Cron"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
This module needs to be loaded after `Magento_Cron` to work, but because the ordering of `config.php` is undefined outside of explicit sequencing statements, it may or may not happen.

The exact symptom is that the frontend breaks with this error in development mode:

    Exception #0 (BadMethodCallException): Missing required argument $routerList of Magento\Framework\App\RouterList.

And this log error in production mode (frontend symptom is a white screen of death):

    PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Magento\Framework\App\RouterList::__construct() must be of the type array, null given

The error is directly caused by this segment in `di.xml`, which is copied from `magento-cron`:

    <type name="Magento\Framework\App\AreaList">
        <arguments>
            <argument name="areas" xsi:type="array">
                <item name="crontab" xsi:type="null" />
            </argument>
        </arguments>
    </type>

I'm not sure that needs to be there at all, but I have not removed it in case there is a reason I'm not seeing. That XML does not cause an issue so long as this is correctly sequenced after `Magento_Cron`.