### PR TITLE
Fixes #61 - Undefined variable: runtime

### DIFF
--- a/view/adminhtml/templates/reports.phtml
+++ b/view/adminhtml/templates/reports.phtml
@@ -47,6 +47,7 @@
   foreach ($jobs as $job_code=>$job) {
     if ($job["executed_at"] == 'N/A') {
       $executed = $job["executed_at"];
+      $runtime = '';
     } else {
       $executed = strtotime($job["executed_at"]);
       $executed = date("Y-m-d h:i:s A",($executed - $timediff));

--- a/view/adminhtml/templates/reports.phtml
+++ b/view/adminhtml/templates/reports.phtml
@@ -51,7 +51,7 @@
     } else {
       $executed = strtotime($job["executed_at"]);
       $executed = date("Y-m-d h:i:s A",($executed - $timediff));
-      $runtime = strtotime($job["finished_at"]) - strtotime($job["executed_at"]);
+      $runtime = strtotime($job["finished_at"]) - strtotime($job["executed_at"]) .'s';
     }
     //print_r($job);
     print '<tr>';
@@ -62,7 +62,7 @@
     print '<td style="padding: 4px;">'.$job["missed"].'</td>';
     print '<td style="padding: 4px;">'.$job["error"].'</td>';
     print '<td style="padding: 4px;">'.$executed.'</td>';
-    print '<td style="padding: 4px;">'.$runtime.'s</td>';
+    print '<td style="padding: 4px;">'.$runtime.'</td>';
     print '<td style="padding: 4px;"><a href="'.$block->getUrl("magemojocron/reports/execute",array("jobcode" => $job_code)).'">Execute</a></td>';
     print '</tr>';
   }


### PR DESCRIPTION
Initialize $runtime to avoid PHP Notice that crashes display of report (in non-production modes)