### PR TITLE
Using di.xml to fix installation problems

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,5 +15,19 @@
             </argument>
         </arguments>
     </type>
+
+    <!-- Adding proxies for the console commands. These are loaded when setup:install is run
+         and they load other classes, causing a crash of the install process. -->
+    <type name="MageMojo\Cron\Console\Command\CronExecuteCommand">
+        <arguments>
+            <argument name="schedule" xsi:type="object">MageMojo\Cron\Model\Schedule\Proxy</argument>
+        </arguments>
+    </type>
+
+    <type name="MageMojo\Cron\Console\Command\CronCommand">
+        <arguments>
+            <argument name="schedule" xsi:type="object">MageMojo\Cron\Model\Schedule\Proxy</argument>
+        </arguments>
+    </type>
 </config>
 


### PR DESCRIPTION
When running `setup:install`, all console commands are loaded. If a command relies on a class(es) that have database calls in their constructor, the installation will error out.

This is a scenario that is not often tested as this is an installation from scratch with the Composer dependencies loaded.

This update has been working well for us.