### PR TITLE
Fix for Area code is already.

### DIFF
--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -544,8 +544,12 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
       $schedule = array('scheduled_at' => time());
       $scheduled = $this->resource->saveSchedule($jobconfig, time(), $schedule);
 
-      $state = ObjectManager::getInstance()->get("Magento\Framework\App\State");
-      $state->setAreaCode("crontab");
+      try {
+       $state = ObjectManager::getInstance()->get("Magento\Framework\App\State");
+       $state->setAreaCode("crontab");
+      } catch (\Exception $exception) {
+       // handle exception
+      }
       $areaList = ObjectManager::getInstance()->get(AreaList::class);
       $areaList->getArea(Area::AREA_CRONTAB)->load(Area::PART_TRANSLATE);
 


### PR DESCRIPTION
Proposed fix for {"0":"Area code is already set","1":"<pre>#1 Magento\\Framework\\App\\State\\Interceptor->___callParent() while executing System --> MageMojo Report --> Execute button to force Cron task run.