### PR TITLE
Bugfix checkCronExpression function

### DIFF
--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -262,7 +262,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
         }
         $i = explode('-',$e);
         if (count($i) == 2) {
-          if (($value > $i[0]) and ($value < $i[1])) {
+          if (($value >= $i[0]) and ($value <= $i[1])) {
             return true;
           }
         }


### PR DESCRIPTION
If cron expression has '-', then execution timing has no border value.

example:  if "1-5" then it means "2,3,4", don't include 1,5.  