### PR TITLE
#129 ensure running jobs are not abandoned in cluster env

### DIFF
--- a/Model/ResourceModel/Schedule.php
+++ b/Model/ResourceModel/Schedule.php
@@ -106,7 +106,7 @@ class Schedule extends AbstractDb
       $connection = $this->getConnection();
       $updatedata = array('status' => $status);
       $updatedata["messages"] = $output;
-      if ($status == 'success') {
+      if ($status == 'success' || $status == 'error') {
         $updatedata["finished_at"] = date('Y-m-d H:i:s',time());
       }
       if ($status == 'running') {
@@ -198,7 +198,7 @@ class Schedule extends AbstractDb
             ->from($this->getTable('cron_schedule'))
             ->where('status = ?',$status);
       if (!empty($host)){
-          $select = $select->where('execution_host',$host);
+          $select = $select->where('execution_host = ?',$host);
       }
       $result = $connection->fetchAll($select);
       return $result;

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -132,7 +132,8 @@ class Schedule extends AbstractModel
         ini_set('max_execution_time', 0);
         #Handle SIGTERM event with graceful shutdown
         pcntl_async_signals(true);
-        pcntl_signal(SIGTERM, 'handleExit');
+        pcntl_signal(SIGTERM, [$this, 'handleExit']);
+        pcntl_signal(SIGINT, [$this, 'handleExit']);
         #Set transaction name for New Relic, if installed
         if (extension_loaded ('newrelic')) {
             newrelic_name_transaction ('magemojo_cron');
@@ -1028,7 +1029,7 @@ class Schedule extends AbstractModel
      *
      * @return void
      */
-    private function handleExit()
+    public function handleExit()
     {
         while(($runningPids = $this->checkRunningJobs()) > 0){
             $this->printInfo("Cron Shutdown Requested. Waiting for $runningPids jobs to complete.");
@@ -1039,6 +1040,7 @@ class Schedule extends AbstractModel
             # check jobs/clean up
             $this->asylum();
         }
+        $this->printInfo("Cron Shutdown successful.");
 
         exit;
     }

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -850,7 +850,7 @@ class Schedule extends AbstractModel
     public function cleanup() {
         $this->basedir = $this->directoryList->getRoot();
         $this->checkCronFolderExistence();
-        $this->initialize();
+        $this->getRuntimeParameters();
         /* gets a list of all schedule ids in the cron table */
         $scheduleids = $this->resource->cleanSchedule($this->history);
         /* gets a list of all cron schedule output files */

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -559,7 +559,7 @@ class Schedule extends AbstractModel
 
             $this->getRuntimeParameters();
             if ($this->cronenabled == 0) {
-                $this->printWarn("Stopped Cron Service by maintenance is enabled");
+                $this->printWarn("Stopped Cron Service. Cron disabled.");
                 $this->exit();
             }
 

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -598,6 +598,7 @@ class Schedule extends AbstractModel
                     if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
                         $consumerName = str_replace("mm_consumer_","",(string)$jobconfig["name"]);
                         if (!$this->canExecuteConsumer($consumerName)) {
+                            $this->setJobStatus($job["schedule_id"],'running','', $this->hostname);
                             $this->setJobStatus($job["schedule_id"],'success','No messages to process.');
                             continue;
                         }

--- a/Model/stub.txt
+++ b/Model/stub.txt
@@ -1,1 +1,41 @@
-require "<<basedir>>/app/bootstrap.php"; if (extension_loaded ("newrelic")) { newrelic_name_transaction ("<<name>>");} try{ $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER); $obj = $bootstrap->getObjectManager(); $scheduleid = <<scheduleid>>; $state = $obj->get("Magento\Framework\App\State"); $state->setAreaCode("crontab"); $areaList = $obj->get("Magento\Framework\App\AreaList"); $areaList->getArea("crontab")->load("translate"); $instance = $obj->get("<<instance>>"); $schedule = $obj->get("\Magento\Cron\Model\Schedule")->load($scheduleid); $instance-><<method>>($schedule);} catch (Throwable $t) { echo "Cron Execution Error",$t->getMessage(),"\n"; if (extension_loaded ("newrelic")){newrelic_notice_error($t);}}
+require "<<basedir>>/app/bootstrap.php";
+$thisPid = getmypid();
+if (extension_loaded ("newrelic")) {
+    newrelic_name_transaction ("<<name>>");
+}
+$success = false;
+$errorMessage = null;
+$resource = null;
+try {
+    $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+    $obj = $bootstrap->getObjectManager();
+    $logger = $obj->get("Psr\Log\LoggerInterface");
+    $resource = $obj->get("\MageMojo\Cron\Model\ResourceModel\Schedule");
+
+    /* Update job record to indicate the job is running */
+    $resource->setJobStatus(<<scheduleid>>, 'running', null, gethostname());
+
+    $logger->debug("Cron Job <<name>> schedule <<scheduleid>> running with pid $thisPid.");
+    $scheduleid = <<scheduleid>>;
+    $state = $obj->get("Magento\Framework\App\State");
+    $state->setAreaCode("crontab");
+    $areaList = $obj->get("Magento\Framework\App\AreaList");
+    $areaList->getArea("crontab")->load("translate");
+    $instance = $obj->get("<<instance>>");
+    $schedule = $obj->get("\Magento\Cron\Model\Schedule")->load($scheduleid);
+    $instance-><<method>>($schedule);
+    $logger->debug("Cron Job <<name>> schedule <<scheduleid>> finished successfully.");
+    $success = true;
+} catch (Throwable $t) {
+    $success = false;
+    $errorMessage = "Error running Cron Job <<name>> schedule <<scheduleid>>: " . $t->getMessage();
+    print $errorMessage;
+    $logger->error($errorMessage,['exception'=>$t]);
+    if (extension_loaded ("newrelic")){
+        newrelic_notice_error($t);
+    }
+} finally {
+    if ($resource){
+        $resource->setJobStatus(<<scheduleid>>, $success ? 'success' : 'error', $errorMessage);
+    }
+}


### PR DESCRIPTION
**tl;dr Fixes #129 and improves on the recent consumer job changes. Also improves dev ex for the stub file. Handles `SIGTERM`.**

#### Service Exit
If the service has been requested to exit (cron disabled, new cluster leader takes over, `SIGTERM` etc.), the service would simply exit. In environments like Kubernetes, where the cron service is monitored, this could cause the container to be stopped abruptly, killing any running jobs. This change adds a `handleExit()` method, which first waits for the running jobs to finish before shutting down.

#### Better consumer handling
In the most recent release, an improvement was made to only run consumer jobs if there are messages in the queue. However, the jobs would then be marked as missed once messages were available. This change updates the job correctly and adds a message indicating that no messages were waiting to be processed.

#### Developer Experience
Added formatting of the stub file with whitespace stripping. This makes the functionality of the stub easier to understand and work with, and should also help with tracking changes to that file in the future.

#### Logging 
Updated echo to use the existing. `print` method / logging pattern.