### PR TITLE
#131 fix incompatibility with remote storage

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -40,6 +40,11 @@
             <argument name="cronconfig" xsi:type="object">MageMojoCronConfig</argument>
         </arguments>
     </type>
-
+    <!-- https://github.com/magemojo/m2-ce-cron/issues/131 -->
+    <type name="Magento\Framework\App\MaintenanceMode">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem</argument>
+        </arguments>
+    </type>
 </config>
 


### PR DESCRIPTION
## Overview / Background

Fixes #131 

When the Remote Storage implementation for AWS S3 is enabled, the module sets a preference for maintenance mode to use the remote filesystem (https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/RemoteStorage/etc/di.xml#L77-L80). The implementation uses a caching mechanism that results in the cron service never coming out of maintenance mode. The FileSystem object detects the maintenance flag being written, but then continues to use the cache of the file's existence (https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/RemoteStorage/Driver/Adapter/CachedAdapter.php#L139-L143). The only way to bring the cron service out of maintenance mode is to restart it

This change adds a preference to force the maintenance flag to be written using the standard filesystem implementation. A shared var dir mount is current practice for Commerce Cloud and a standard pattern for other clustered environments.

## Testing
Start the cron service and observe it running without issue.
Enable maintenance mode.
Overserve the cron service pausing during maintenance mode.
Disable maintenance mode.
Observe the cron service resume.