### PR TITLE
Fix strtotime null values issue 

### DIFF
--- a/view/adminhtml/templates/reports.phtml
+++ b/view/adminhtml/templates/reports.phtml
@@ -49,9 +49,11 @@
       $executed = $job["executed_at"];
       $runtime = '';
     } else {
-      $executed = strtotime((string)$job["executed_at"]);
-      $executed = date("Y-m-d h:i:s A",($executed - $timediff));
-      $runtime = strtotime((string)$job["finished_at"]) - strtotime((string)$job["executed_at"]) .'s';
+        $executed = strtotime((string) $job["executed_at"]) ?? '';
+        $executed = $executed ? date("Y-m-d h:i:s A",($executed - $timediff)) : '';
+        $finished = strtotime((string) $job["finished_at"]) ?? '';
+        $runtime = ($finished !== '' && $executed !== '') ?
+            strtotime($job["finished_at"]) - strtotime($job["executed_at"]) . 's' : '';
     }
     //print_r($job);
     print '<tr>';


### PR DESCRIPTION
There is an error caused by a null value in the **cron_schedule** table. To resolve this issue, please examine the provided screenshots and accept the necessary modifications to enable the report page to display even when there are null values received from the **executed_at** and **finished_at** columns to the report page.

<img width="1427" alt="Screen Shot 2023-02-16 at 17 49 47" src="https://user-images.githubusercontent.com/43228234/219383404-06bcfa9e-ece3-4444-bb65-5b32ffc26af8.png">

![Screen Shot 2023-02-16 at 09 59 52](https://user-images.githubusercontent.com/43228234/219382324-ef3a8062-b02b-481b-a79b-5c5ef24d390a.png)
