### PR TITLE
134 add additional index for getJobsByStatus call

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -3,7 +3,8 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="cron_schedule" resource="default" engine="innodb" comment="Cron Schedule">
         <column xsi:type="varchar" name="execution_host" nullable="true" length="255" comment="Execution Host"/>
-        <index referenceId="CRON_SCHEDULE_EXECUTION_HOST" indexType="btree">
+        <index referenceId="CRON_SCHEDULE_STATUS_EXECUTION_HOST" indexType="btree">
+            <column name="status"/>
             <column name="execution_host"/>
         </index>
         <index referenceId="CRON_SCHEDULE_SCHEDULED_AT_HOST_STATUS" indexType="btree">


### PR DESCRIPTION
### Overview 
As the `cron_schedule` table grows before it is cleaned, the performance of the `getJobsByStatus` call degrades due to a missing table index.

### Testing
Prior to pulling this down, run the following SQL against your db and notice that no index is used.
<img width="743" alt="CleanShot 2023-02-26 at 12 36 08@2x" src="https://user-images.githubusercontent.com/10249540/221426686-117fec25-58e1-45dd-894d-ef53220aaf68.png">

After installing, run the same query 
<img width="1139" alt="CleanShot 2023-02-26 at 12 37 25@2x" src="https://user-images.githubusercontent.com/10249540/221426759-776d23c8-9f72-4d2a-ba11-5f47eb2378ec.png">
