### PR TITLE
#120 add ACL for admin visibility

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="MageMojo_Cron::heading" title="MageMojo Cron" translate="title" sortOrder="79">
+                    <resource id="MageMojo_Cron::settings" title="Cron Configuration" translate="title" sortOrder="1"/>
+                    <resource id="MageMojo_Cron::reports" title="Cron Execution Report" translate="title" sortOrder="1"/>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
Adds an ACL so admin users can be granted access to cron configs and/or reports.

![image](https://github.com/magemojo/m2-ce-cron/assets/10249540/1236892a-8b44-4baf-b01b-37c9e94fcbbf)

![CleanShot 2023-09-08 at 12 50 04@2x](https://github.com/magemojo/m2-ce-cron/assets/10249540/cc916d44-96a1-43be-965c-671e1f7b9f80)

