### PR TITLE
#138 fix consumer cron output if governor is disabled

### DIFF
--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -960,7 +960,7 @@ class Schedule extends AbstractModel
 
             if (!$this->checkProcess($pid)) {
                 #IF this is a consumers job it was run under strace and we do not want this output
-                if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
+                if ($this->governor && isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
                     $output = '';
                 } else {
                     $output = $this->getJobOutput($scheduleid);


### PR DESCRIPTION
Fix bug related to consumer governors (#138). The comment states that it's skipping output due to `strace` being used, but that only happens when the consumers governor is set. Added a check for the governor being enabled.