### PR TITLE
fix error an empty cron expression.

### DIFF
--- a/Console/Command/CronCommand.php
+++ b/Console/Command/CronCommand.php
@@ -72,6 +72,12 @@ class CronCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-    	$this->schedule->execute();
+        try {
+            $this->schedule->execute();
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln('Error: '.$e->getMessage());
+            return Command::FAILURE;
+        }
     }
 }

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -351,7 +351,9 @@ class Schedule extends AbstractModel
         $allowedConsumers = $this->deploymentConfig->get('cron_consumers_runner/consumers', []);
         $runConsumersInCron = $this->deploymentConfig->get('cron_consumers_runner/cron_run', true);
         foreach($this->config as $job) {
-            if (isset($job["schedule"])) {
+            if(isset($job["schedule"]) && empty($job['schedule'])) {
+                $this->printWarn('The schedule element in a job array is EMPTY (disabled cronjob) : '.var_export($job, true));
+            } elseif (isset($job["schedule"]) && !empty($job['schedule'])) {
                 $schedule = array();
                 $expr = explode(' ',(string)$job["schedule"]);
                 $buildtime = (floor($from/60)*60);


### PR DESCRIPTION
Disabling a certain cron job causes all `create schedule` operations to fail. The debugging logs below show that when the cron job is active, the `schedule` contains a cron expression as expected. However, when a cron job is disabled (job_code is backend_clean_cache), the `schedule` is empty, lacking the necessary cron expression, which leads to an error. This issue has been fixed.

```bash
[2024-08-19T22:16:06.746199+09:00] logger.DEBUG: array (   'name' => 'currency_rates_update',   'instance' => 'Magento\\Directory\\Model\\Observer',   'method' => 'scheduledUpdateCurrencyRates',   'config_path' => 'crontab/default/jobs/currency_rates_update/schedule/cron_expr',   'schedule' => '0 0 * * *',   'group' => 'default',   'consumers' => false, ) [] []
[2024-08-19T22:16:06.746403+09:00] logger.DEBUG: array (   'name' => 'backend_clean_cache',   'instance' => 'Magento\\Backend\\Cron\\CleanCache',   'method' => 'execute',   'schedule' => '',   'group' => 'default',   'consumers' => false, ) [] []
```

and another issue fix: [#issue-2225044550](https://github.com/magemojo/m2-ce-cron/issues/141#issue-2225044550)
`Symfony\Component\Console\Command\Command class` needs the exit code.